### PR TITLE
fix: Update button labels and logic on top page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,20 +143,20 @@ export default function Home() {
                         <Copy className="mr-2 h-4 w-4" />
                         共有URLをコピー
                       </Button>
+                      {!answeredPurposeIds.has(purpose.id) && (
+                        <Link href={`/share/${purpose.shareToken}`}>
+                          <Button variant="outline" size="sm">
+                            <Edit className="mr-2 h-4 w-4" />
+                            回答を実施
+                          </Button>
+                        </Link>
+                      )}
                       <Link href={`/analysis/${purpose.id}`}>
                         <Button variant="outline" size="sm">
                           <BarChart3 className="mr-2 h-4 w-4" />
                           集計を確認
                         </Button>
                       </Link>
-                      {answeredPurposeIds.has(purpose.id) && (
-                        <Link href={`/share/${purpose.shareToken}`}>
-                          <Button variant="outline" size="sm">
-                            <Edit className="mr-2 h-4 w-4" />
-                            自分の回答を編集
-                          </Button>
-                        </Link>
-                      )}
                       {purpose.deadline && (
                         <span className="text-sm text-slate-500 self-center ml-auto">
                           締切: {new Date(purpose.deadline).toLocaleDateString('ja-JP')}
@@ -200,7 +200,7 @@ export default function Home() {
                       <Link href={`/share/${purpose.shareToken}`}>
                         <Button variant="outline" size="sm">
                           <Edit className="mr-2 h-4 w-4" />
-                          自分の回答を編集
+                          回答を編集
                         </Button>
                       </Link>
                       <Link href={`/analysis/${purpose.id}`}>


### PR DESCRIPTION
## Summary
- 作成済みアンケート欄: 未回答の場合のみ「回答を実施」ボタンを表示（回答済みの場合は非表示）
- 回答済みアンケート欄: 「自分の回答を編集」→「回答を編集」に文言変更
- ボタンの順序を調整: 回答ボタンを集計確認ボタンの前に配置

## Changes
- `src/app/page.tsx`: ボタンの表示ロジックとラベルを修正

## Test plan
- [ ] トップページで作成済みアンケート（未回答）に「回答を実施」ボタンが表示される
- [ ] トップページで作成済みアンケート（回答済み）に回答ボタンが表示されない
- [ ] 回答済みアンケート欄で「回答を編集」ボタンが表示される
- [ ] 各ボタンが正しく機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)