### PR TITLE
feat: Add back button to answer edit page

### DIFF
--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -7,7 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Send, AlertCircle } from 'lucide-react';
+import { Send, AlertCircle, ArrowLeft } from 'lucide-react';
 import { Question, Answer, AnswerValue } from '@/types/survey';
 import { getOrCreateClientId, hasAnswered, markAsAnswered } from '@/lib/storage';
 
@@ -277,6 +277,16 @@ export default function SharePage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 py-12">
       <div className="container mx-auto px-4 max-w-3xl">
+        {alreadyAnswered && (
+          <Button
+            variant="ghost"
+            onClick={() => router.back()}
+            className="mb-6"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            前のページに戻る
+          </Button>
+        )}
         {alreadyAnswered && (
           <Card className="mb-6 border-amber-200 bg-amber-50">
             <CardContent className="pt-6">


### PR DESCRIPTION
## Summary
回答編集画面（共有URL）に「前のページに戻る」ボタンを追加しました。

## Changes
- `src/app/share/[token]/page.tsx`: 回答編集時（`alreadyAnswered`が`true`の場合）に「前のページに戻る」ボタンを表示
- `ArrowLeft`アイコンをインポート
- `router.back()`を使用して前のページに遷移

## Implementation Details
- ボタンは回答編集時のみ表示（初回回答時は表示されない）
- 警告カードの前に配置
- `router.back()`で遷移元ページに戻る

## Test plan
- [ ] 初回回答時はボタンが表示されない
- [ ] 回答編集時（2回目以降）はボタンが表示される
- [ ] ボタンクリックで前のページに戻る
- [ ] トップページ→回答編集→戻るボタンでトップページに戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)