### PR TITLE
fix: Always show back button on answer page

### DIFF
--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -277,16 +277,14 @@ export default function SharePage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 py-12">
       <div className="container mx-auto px-4 max-w-3xl">
-        {alreadyAnswered && (
-          <Button
-            variant="ghost"
-            onClick={() => router.back()}
-            className="mb-6"
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            前のページに戻る
-          </Button>
-        )}
+        <Button
+          variant="ghost"
+          onClick={() => router.back()}
+          className="mb-6"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          前のページに戻る
+        </Button>
         {alreadyAnswered && (
           <Card className="mb-6 border-amber-200 bg-amber-50">
             <CardContent className="pt-6">


### PR DESCRIPTION
## Summary
READMEの更新に従い、回答ページの「前のページに戻る」ボタンを常に表示するように変更しました。

## Changes
- `src/app/share/[token]/page.tsx`: `alreadyAnswered`条件を削除し、常に戻るボタンを表示

## README変更内容
- **変更前** (Line 255): 「アンケート編集（初回作成の場合は除く）時にはヘッダーに「前のページに戻る」ボタンを用意する」
- **変更後** (Line 255): 「アンケート編集時にはヘッダーに「前のページに戻る」ボタンを用意する」

## Implementation Details
- 初回回答時も編集時も常に「前のページに戻る」ボタンを表示
- `router.back()`で前のページに遷移

## Test plan
- [ ] 初回回答時も戻るボタンが表示される
- [ ] 回答編集時も戻るボタンが表示される
- [ ] ボタンクリックで前のページに戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)