### PR TITLE
feat: Add deadline input to survey edit page

### DIFF
--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -17,6 +17,7 @@ function EditPageContent() {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [questions, setQuestions] = useState<Question[]>([]);
+  const [deadline, setDeadline] = useState('');
   const [loading, setLoading] = useState(false);
   const [regenerating, setRegenerating] = useState(false);
 
@@ -89,7 +90,7 @@ function EditPageContent() {
           title,
           description,
           questions,
-          deadline: null,
+          deadline: deadline ? new Date(deadline).toISOString() : null,
           createdBy: clientId,
         }),
       });
@@ -230,6 +231,26 @@ function EditPageContent() {
             </Card>
           ))}
         </div>
+
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle className="text-lg">アンケート締切日（任意）</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              <Label htmlFor="deadline">締切日時</Label>
+              <Input
+                id="deadline"
+                type="datetime-local"
+                value={deadline}
+                onChange={(e) => setDeadline(e.target.value)}
+              />
+              <p className="text-sm text-slate-500">
+                締切日を設定しない場合は空欄のままにしてください
+              </p>
+            </div>
+          </CardContent>
+        </Card>
 
         <div className="flex gap-4">
           <Button


### PR DESCRIPTION
## 目的
AI生成されたアンケートとは別に、締切日を任意項目として追加しました。
README Line 229 の要件に対応しています。

## 差分
### 変更ファイル
- `src/app/edit/page.tsx`

### 主な変更内容
1. `deadline` state を追加
2. AI生成質問一覧の後に「アンケート締切日（任意）」セクションを追加
   - `datetime-local` 型の Input コンポーネントを使用
   - 締切日を設定しない場合は空欄のまま
3. 保存ハンドラーで `deadline` の処理を追加
   - 入力がある場合: `new Date(deadline).toISOString()` で ISO 形式に変換
   - 空欄の場合: `null` として保存

## 影響
- アンケート確認・編集ページに締切日入力欄が追加されます
- 既存のアンケートには影響ありません（締切日なしで保存可能）
- トップページ・集計ページでの締切日表示機能は既に実装済みのため、本PRで設定した締切日が正しく表示されます

## テスト状況
- ✅ TypeScript ビルド成功
- 手動テスト項目:
  - [ ] 目的作成ページからアンケート生成
  - [ ] 編集ページで締切日を入力して保存
  - [ ] 締切日を空欄にして保存
  - [ ] トップページで締切日が正しく表示される
  - [ ] 集計ページで締切日が正しく表示される

## レビューポイント
- 締切日入力欄の配置位置（AI生成質問の後、保存ボタンの前）
- `datetime-local` 型の使用
- 空欄時の `null` 処理
- ISO形式への変換処理

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>