### PR TITLE
fix: Add activation constraint to PointerSensor for drag and drop

### DIFF
--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -201,7 +201,11 @@ function EditPageContent() {
   const [regenerating, setRegenerating] = useState(false);
 
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     })


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

ドラッグ&ドロップが動作しない問題を修正しました。

PointerSensorのデフォルト設定では、わずかなマウス移動でもドラッグが開始されてしまい、input要素のクリックやテキスト選択と干渉していました。

## Changes

### `src/app/edit/page.tsx`
- PointerSensorに`activationConstraint`を追加
- 8px以上の移動でドラッグが開始されるように設定
- これにより、意図的なドラッグのみが検知されます

## Before / After

**Before:**
- ドラッグアイコンをクリックしてもドラッグが開始されない
- または、input要素をクリックするとすぐにドラッグモードになってしまう

**After:**
- GripVerticalアイコン（≡）を8px以上ドラッグすることで質問の順番を入れ替えられます
- input要素のクリックやテキスト選択が正常に動作します

## Technical Details

`activationConstraint.distance: 8`を設定することで:
- マウスポインタが8px以上移動するまでドラッグが開始されない
- 誤クリックや意図しないドラッグを防止
- より直感的なユーザー体験を提供

## Test plan

- [ ] /editページでアンケートを作成
- [ ] 質問カード左端のGripVerticalアイコン（≡）をドラッグして順番を入れ替え
- [ ] input要素をクリックして文字入力ができることを確認
- [ ] テキストを選択できることを確認
- [ ] ドラッグ中に要素が半透明になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)