### PR TITLE
fix: 日付入力で空文字列をnullに変換

### DIFF
--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -255,7 +255,11 @@ export default function SharePage() {
           <Input
             type="date"
             value={(answers[question.id] as string) || ''}
-            onChange={(e) => handleAnswerChange(question.id, e.target.value)}
+            onChange={(e) => {
+              const value = e.target.value;
+              // 空文字列の場合はnullを設定（必須バリデーションで検出できるように）
+              handleAnswerChange(question.id, value === '' ? null : value);
+            }}
           />
         );
 


### PR DESCRIPTION
## 問題

日付入力フィールドがクリアされた際、空文字列(`''`)が設定されるため、必須バリデーションが正しく動作していませんでした。

### 具体的な問題
- 日付入力の`onChange`で`e.target.value`をそのまま設定していた
- 値をクリアすると空文字列が`answers[question.id]`に設定される
- バリデーションロジックは空文字列を検出するが、日付入力では空文字列が保存される前に検証される
- 結果として、見た目は空だが、バリデーションをパスできない状態になっていた

## 修正内容

日付入力の`onChange`ハンドラーで、空文字列を`null`に変換するように修正しました（`src/app/share/[token]/page.tsx:258-262`）。

### 変更前
```typescript
onChange={(e) => handleAnswerChange(question.id, e.target.value)}
```

### 変更後
```typescript
onChange={(e) => {
  const value = e.target.value;
  // 空文字列の場合はnullを設定（必須バリデーションで検出できるように）
  handleAnswerChange(question.id, value === '' ? null : value);
}}
```

## 効果

- ✅ 日付入力をクリアした際、`null`が設定される
- ✅ 必須バリデーションが正しく「未回答」として検出する
- ✅ ユーザーが日付を選択しない場合、適切にエラーメッセージが表示される

## テスト

- ビルド成功を確認
- 日付入力で空文字列が`null`に変換されることを確認