### PR TITLE
fix: 日付入力のプレースホルダー色を他の入力と統一

### DIFF
--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -261,6 +261,7 @@ export default function SharePage() {
               handleAnswerChange(question.id, value === '' ? null : value);
             }}
             placeholder="日付を選択してください"
+            className="[&::-webkit-datetime-edit-text]:text-muted-foreground [&::-webkit-datetime-edit-month-field]:text-muted-foreground [&::-webkit-datetime-edit-day-field]:text-muted-foreground [&::-webkit-datetime-edit-year-field]:text-muted-foreground"
           />
         );
 


### PR DESCRIPTION
## 問題

日付入力のプレースホルダー部分が青色で表示され、他の入力フィールドのプレースホルダー（グレー系）と色が異なっていました。

## 修正内容

日付入力に対して、WebKitベースのブラウザ用のカスタムスタイルを追加し、プレースホルダーの色を`text-muted-foreground`に統一しました（`src/app/share/[token]/page.tsx:264`）。

### 追加したスタイル

```typescript
className="[&::-webkit-datetime-edit-text]:text-muted-foreground 
  [&::-webkit-datetime-edit-month-field]:text-muted-foreground 
  [&::-webkit-datetime-edit-day-field]:text-muted-foreground 
  [&::-webkit-datetime-edit-year-field]:text-muted-foreground"
```

これにより、日付入力の各パーツ（年、月、日、区切り文字）の色が他の入力フィールドと同じグレー系の色になります。

## 対象ブラウザ

- Chrome
- Safari
- Edge（Chromiumベース）
- その他WebKitベースのブラウザ

## 効果

- ✅ UIの一貫性が向上
- ✅ 他の入力フィールドと同じ視覚的スタイル
- ✅ ユーザー体験の改善